### PR TITLE
Fix binder link

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ They are intended to be educational and give users a start on common workflows.
 They should be easy to run locally if you download this repository.
 They are also available on the cloud by clicking on the link below:
 
-[![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/xarray_contrib/binder-tutorial/master) [![Build Status](https://travis-ci.org/xarray-contrib/binder-tutorial.svg?branch=master)](https://travis-ci.org/xarray-contrib/binder-tutorial)
+[![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/xarray-contrib/binder-tutorial/master) [![Build Status](https://travis-ci.org/xarray-contrib/binder-tutorial.svg?branch=master)](https://travis-ci.org/xarray-contrib/binder-tutorial)
 
 Contributing
 ------------


### PR DESCRIPTION
Binder could't resolve the URL. Uses correct hyphen instead of underscore now.